### PR TITLE
Fix: 모임 추천 리스트 - 그룹원들이 선택한 시간 중에서, 모임 시간동인 겹치는 시간대 조회

### DIFF
--- a/src/test/java/com/ll/MOIZA/boundedContext/selectedTime/service/SelectedTimeServiceQueryTest.java
+++ b/src/test/java/com/ll/MOIZA/boundedContext/selectedTime/service/SelectedTimeServiceQueryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.ll.MOIZA.boundedContext.member.entity.Member;
 import com.ll.MOIZA.boundedContext.member.repository.MemberRepository;
-import com.ll.MOIZA.boundedContext.room.entity.EnterRoom;
 import com.ll.MOIZA.boundedContext.room.entity.Room;
 import com.ll.MOIZA.boundedContext.room.repository.EnterRoomRepository;
 import com.ll.MOIZA.boundedContext.room.repository.RoomRepository;
@@ -64,7 +63,7 @@ public class SelectedTimeServiceQueryTest {
                 LocalDate.now().plusDays(6));
 
         List<TimeRangeWithMember> overlappingRanges = selectedTimeService.findOverlappingTimeRanges(
-                selectedTimeList, room.getMeetingDuration()
+                selectedTimeList, room.getMeetingDuration().minusHours(1)
         );
 
         for (TimeRangeWithMember t : overlappingRanges) {
@@ -77,23 +76,16 @@ public class SelectedTimeServiceQueryTest {
 
         TimeRangeWithMember t1 = overlappingRanges.get(0);
         TimeRangeWithMember t2 = overlappingRanges.get(1);
-        TimeRangeWithMember t3 = overlappingRanges.get(2);
         assertAll(
                 () -> assertThat(t1.getDate()).isEqualTo(LocalDate.now().plusDays(6)),
-                () -> assertThat(t1.getStart()).isEqualTo(LocalTime.of(7, 0)),
+                () -> assertThat(t1.getStart()).isEqualTo(LocalTime.of(8, 0)),
                 () -> assertThat(t1.getEnd()).isEqualTo(LocalTime.of(10, 0)),
-                () -> assertThat(t1.getMembers()).isEqualTo(List.of(member1, member2)),
+                () -> assertThat(t1.getMembers()).isEqualTo(List.of(member1, member2, member3)),
 
                 () -> assertThat(t2.getDate()).isEqualTo(LocalDate.now().plusDays(6)),
-                () -> assertThat(t2.getStart()).isEqualTo(LocalTime.of(15, 0)),
-                () -> assertThat(t2.getEnd()).isEqualTo(LocalTime.of(17, 0)),
-                () -> assertThat(t2.getMembers()).isEqualTo(List.of(member1, member2)),
-
-                () -> assertThat(t3.getDate()).isEqualTo(LocalDate.now().plusDays(6)),
-                () -> assertThat(t3.getStart()).isEqualTo(LocalTime.of(8, 0)),
-                () -> assertThat(t3.getEnd()).isEqualTo(LocalTime.of(12, 0)),
-                () -> assertThat(t3.getMembers()).isEqualTo(List.of(member3))
-
+                () -> assertThat(t2.getStart()).isEqualTo(LocalTime.of(11, 0)),
+                () -> assertThat(t2.getEnd()).isEqualTo(LocalTime.of(13, 0)),
+                () -> assertThat(t2.getMembers()).isEqualTo(List.of(member1, member2, member3))
         );
     }
 }


### PR DESCRIPTION
기존 코드 오류로 인해 수정필요

- [x] 사용자가 입력한 시간을 오름차순 정렬한다. 시작 시각, 끝나는 시간순
- [x] 0시부터 24시까지 30분 단위로 탐색한다.
    - [x] 시작 시각부터 모임 소요 시간의 범위 내에 있으면 그룹원을 추가한다.
    - [x] 시작 시각부터 모임 소요 시간의 범위 내에서 벗어나면 그룹원을 삭제한다.
    - [x] 시작 시각부터 모임 소요 시간의 범위, 그룹원 리스트를 저장한다.
- [x] 그룹원의 인원수가 많은 순으로 내림차순 정렬한다. 만약 같다면 빠른 시작 시간순

closes #17 