### PR TITLE
Cached chat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	// 메시지 이스케이프
 	// https://mvnrepository.com/artifact/org.apache.commons/commons-text
 	implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ll/MOIZA/base/redis/RedisConfig.java
+++ b/src/main/java/com/ll/MOIZA/base/redis/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.ll.MOIZA.base.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.MOIZA.boundedContext.chat.document.Chat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+    private final ObjectMapper objectMapper;
+
+    private final LettuceConnectionFactory lettuceConnectionFactory;
+
+    @Bean
+    public RedisTemplate<String, Chat> redisTemplate() {
+        RedisTemplate<String, Chat> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, Chat.class));
+        redisTemplate.setConnectionFactory(lettuceConnectionFactory);
+        return redisTemplate;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        final StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
+        stringRedisTemplate.setConnectionFactory(lettuceConnectionFactory);
+        return stringRedisTemplate;
+    }
+}

--- a/src/main/java/com/ll/MOIZA/boundedContext/chat/document/Chat.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/chat/document/Chat.java
@@ -1,10 +1,7 @@
 package com.ll.MOIZA.boundedContext.chat.document;
 
 import jakarta.persistence.EntityListeners;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -20,7 +17,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @EntityListeners(AuditingEntityListener.class)
-public class Chat {
+public class Chat implements Comparable<Chat>{
     @Id
     private String id;
 
@@ -33,8 +30,15 @@ public class Chat {
     private String content;
 
     @CreatedDate
+    @Setter
     private LocalDateTime createDate;
 
     @LastModifiedDate
+    @Setter
     private LocalDateTime modifyDate;
+
+    @Override
+    public int compareTo(Chat o) {
+        return createDate.isBefore(o.createDate) ? -1 : 1;
+    }
 }

--- a/src/main/java/com/ll/MOIZA/boundedContext/chat/repository/CachedChatRepository.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/chat/repository/CachedChatRepository.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.MOIZA.boundedContext.chat.document.Chat;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -48,7 +49,8 @@ public class CachedChatRepository {
         return chat;
     }
 
-    public Cursor<Chat> findByRoom(String roomId, String serializedChat) throws JsonProcessingException {
+    @SneakyThrows
+    public Cursor<Chat> findByRoom(String roomId, String serializedChat){
         String key = getKey(roomId);
 
         Chat deserializedCursor = null;

--- a/src/main/java/com/ll/MOIZA/boundedContext/chat/repository/CachedChatRepository.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/chat/repository/CachedChatRepository.java
@@ -1,0 +1,88 @@
+package com.ll.MOIZA.boundedContext.chat.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.MOIZA.boundedContext.chat.document.Chat;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.stereotype.Repository;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+@Repository
+@RequiredArgsConstructor
+public class CachedChatRepository {
+    private final RedisTemplate<String, Chat> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private ZSetOperations<String, Chat> operations;
+
+    private static final int PAGE_SIZE = 20;
+
+    private static final int MAX_CACHE = 500;
+
+    @PostConstruct
+    public void init() {
+        operations = redisTemplate.opsForZSet();
+    }
+
+    public Chat save(Chat chat) {
+        chat.setCreateDate(LocalDateTime.now());
+        chat.setModifyDate(LocalDateTime.now());
+
+        String key = getKey(chat.getRoomId());
+
+        operations.add(key, chat, -chat.getCreateDate().toInstant(ZoneOffset.UTC).toEpochMilli());
+
+        //TODO MAX_CHATS 넘으면 벌크삽입
+
+        return chat;
+    }
+
+    public Cursor<Chat> findByRoom(String roomId, String serializedChat) throws JsonProcessingException {
+        String key = getKey(roomId);
+
+        Chat deserializedCursor = null;
+        if (serializedChat != null) {
+            deserializedCursor = objectMapper.readValue(serializedChat, Chat.class);
+        }
+
+        // 커서의 위치를 찾기 위해 커서 이전까지의 개수를 구함
+        Long offset = operations.rank(key, deserializedCursor);
+
+        if (offset == null) {
+            offset = 0L; // 커서가 존재하지 않는 경우, 첫 페이지로 설정
+        }
+
+        Set<Chat> chatSet = Optional.ofNullable(operations.range(key, offset, offset + PAGE_SIZE))
+                .orElse(new LinkedHashSet<>());
+
+
+        boolean hasNext = chatSet.size() > PAGE_SIZE;
+
+        List<Chat> chats = new ArrayList<>(chatSet);
+        Chat nextCursorChat = chats.get(chats.size() - 1);
+        String serializedNextCursor = objectMapper.writeValueAsString(nextCursorChat);
+
+        if (hasNext) {
+            chats = chats.subList(0, PAGE_SIZE);
+        }
+
+        return new Cursor<>(chats, PageRequest.of(0, PAGE_SIZE), hasNext, serializedNextCursor);
+    }
+
+    private String getKey(String roomId) {
+        return "ROOM#%s_CHAT".formatted(roomId);
+    }
+
+    public void clear(String roomId) {
+        redisTemplate.delete("ROOM#%s_CHAT".formatted(roomId));
+    }
+}

--- a/src/main/java/com/ll/MOIZA/boundedContext/chat/service/ChatService.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/chat/service/ChatService.java
@@ -1,6 +1,7 @@
 package com.ll.MOIZA.boundedContext.chat.service;
 
 import com.ll.MOIZA.boundedContext.chat.document.Chat;
+import com.ll.MOIZA.boundedContext.chat.repository.CachedChatRepository;
 import com.ll.MOIZA.boundedContext.chat.repository.ChatRepository;
 import com.ll.MOIZA.boundedContext.chat.repository.Cursor;
 import com.ll.MOIZA.boundedContext.member.entity.Member;
@@ -8,22 +9,20 @@ import com.ll.MOIZA.boundedContext.room.entity.Room;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.StringEscapeUtils;
 import org.bson.types.ObjectId;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.ZoneOffset;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ChatService {
-    private final ChatRepository chatRepository;
+    private final CachedChatRepository chatRepository;
     private final SimpMessagingTemplate messagingTemplate;
-    private final int PAGE_SIZE = 20;
 
     public Chat sendChat(Member member, Room room, String content) {
         return sendChat(member.getId().toString(), member.getName(), member.getProfile(), room.getId().toString(), content);
@@ -31,23 +30,7 @@ public class ChatService {
 
 
     public Cursor<Chat> getChats(Room room, String cursor) {
-        List<Chat> rooms;
-        Pageable pageable = PageRequest.of(0, PAGE_SIZE + 1);
-        if (cursor == null) {
-            rooms = chatRepository.findByRoomId(room.getId().toString(), pageable);
-        } else {
-            rooms = chatRepository.findByRoomIdWithCursor(room.getId().toString(), new ObjectId(cursor), pageable);
-        }
-
-        if (rooms.size() == PAGE_SIZE + 1) {
-            return new Cursor<>(
-                    rooms.subList(0, PAGE_SIZE),
-                    PageRequest.of(0, PAGE_SIZE),
-                    true,
-                    rooms.get(PAGE_SIZE).getId());
-        }
-
-        return new Cursor<>(rooms, PageRequest.of(0, PAGE_SIZE), false, null);
+        return chatRepository.findByRoom(room.getId().toString(), cursor);
     }
 
     public Chat sendChat(String memberId, String username, String profile, String roomId, String content) {

--- a/src/main/java/com/ll/MOIZA/boundedContext/room/controller/RoomController.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/room/controller/RoomController.java
@@ -160,7 +160,9 @@ public class RoomController {
 
     @PreAuthorize("isAuthenticated() && hasAuthority('ROOM#' + #roomId + '_MEMBER')")
     @GetMapping("/{roomId}/chat")
-    public String showRoomChat(@PathVariable Long roomId) {
+    public String showRoomChat(@PathVariable Long roomId, Model model) {
+        Room room = roomService.getRoom(roomId);
+        model.addAttribute("room", room);
         return "status/chat";
     }
 }

--- a/src/main/java/com/ll/MOIZA/boundedContext/room/controller/RoomController.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/room/controller/RoomController.java
@@ -44,8 +44,6 @@ public class RoomController {
     private final MailService mailService;
     private final ResultService resultService;
 
-    private final EnterRoomService enterRoomService;
-
     @Data
     public static class RoomForm {
         @NotNull

--- a/src/main/java/com/ll/MOIZA/boundedContext/room/entity/EnterRoom.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/room/entity/EnterRoom.java
@@ -4,10 +4,7 @@ import com.ll.MOIZA.base.entity.BaseEntity;
 import com.ll.MOIZA.boundedContext.member.entity.Member;
 import com.ll.MOIZA.boundedContext.selectedPlace.entity.SelectedPlace;
 import com.ll.MOIZA.boundedContext.selectedTime.entity.SelectedTime;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,11 +25,11 @@ public class EnterRoom extends BaseEntity {
     @ManyToOne
     private Member member;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "enterRoom")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "enterRoom", cascade = CascadeType.ALL)
     @ToString.Exclude
     @Builder.Default
     private List<SelectedTime> selectedTimes = new ArrayList<>();
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "enterRoom")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "enterRoom", cascade = CascadeType.ALL)
     @ToString.Exclude
     @Builder.Default
     private List<SelectedPlace> selectedPlaces = new ArrayList<>();

--- a/src/main/java/com/ll/MOIZA/boundedContext/room/entity/Room.java
+++ b/src/main/java/com/ll/MOIZA/boundedContext/room/entity/Room.java
@@ -2,6 +2,7 @@ package com.ll.MOIZA.boundedContext.room.entity;
 
 import com.ll.MOIZA.base.entity.BaseEntity;
 import com.ll.MOIZA.boundedContext.member.entity.Member;
+import com.ll.MOIZA.boundedContext.result.entity.DecidedResult;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -38,4 +39,8 @@ public class Room extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "leaderId")
     private Member leader;
+
+    @OneToOne(mappedBy = "room", cascade = CascadeType.ALL)
+    @ToString.Exclude
+    private DecidedResult result;
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -8,3 +8,6 @@ spring:
     properties:
       hibernate:
         dialect:
+logging:
+  level:
+    org.mongodb.driver: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
       hibernate:
         default_batch_fetch_size: 50
         dialect: org.hibernate.dialect.MySQL8Dialect
+  data:
+    redis:
+      url: redis://default:redispw@localhost:55000
   sendgrid:
     api-key: ${SENDGRID_MOIZA}
 custom:

--- a/src/main/resources/templates/status/chat.html
+++ b/src/main/resources/templates/status/chat.html
@@ -51,7 +51,7 @@
                     채팅방
                 </div>
 
-                <div id="chats" class="overflow-auto px-4 pt-2 h-[95%]">
+                <div id="chats" class="overflow-auto px-4 pt-2 h-72">
                     <!-- 채팅내용 -->
                 </div>
             </div>

--- a/src/test/java/com/ll/MOIZA/boundedContext/chat/repository/CachedChatRepositoryTest.java
+++ b/src/test/java/com/ll/MOIZA/boundedContext/chat/repository/CachedChatRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.ll.MOIZA.boundedContext.chat.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.MOIZA.boundedContext.chat.document.Chat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CachedChatRepositoryTest {
+    @Autowired
+    CachedChatRepository cachedChatRepository;
+
+    @Autowired
+    RedisTemplate<String, Chat> redisTemplate;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @AfterEach
+    void clear() {
+        cachedChatRepository.clear("TEST");
+    }
+
+    @Test
+    void redis직렬화_테스트() throws JsonProcessingException {
+        Chat testChat = Chat.builder().roomId("TEST").content("테스트용").build();
+        ZSetOperations<String, Chat> ops = redisTemplate.opsForZSet();
+
+        ops.add("TEST", testChat, 10.0);
+
+        Long offset = ops.reverseRank("TEST", testChat);
+        assertThat(offset).isNotNull();
+
+        redisTemplate.delete("TEST");
+    }
+
+    @Test
+    void 채팅_저장() {
+        Chat testChat = Chat.builder().roomId("TEST").content("테스트용").build();
+        Chat save = cachedChatRepository.save(testChat);
+    }
+
+    @Test
+    void 채팅_페이지네이션() throws JsonProcessingException {
+        for (int i = 0; i < 55; i++) {
+            Chat testChat = Chat.builder().roomId("TEST").memberId("%d".formatted(i)).content("테스트메시지%d".formatted(i)).build();
+            cachedChatRepository.save(testChat);
+        }
+
+        Cursor<Chat> first = cachedChatRepository.findByRoom("TEST", null);
+        Cursor<Chat> second = cachedChatRepository.findByRoom("TEST", first.getNextCursor());
+        Cursor<Chat> third = cachedChatRepository.findByRoom("TEST", second.getNextCursor());
+
+        assertThat(first).hasSize(20);
+        assertThat(first.hasNext()).isTrue();
+        assertThat(second).hasSize(20);
+        assertThat(second.hasNext()).isTrue();
+        assertThat(third).hasSize(15);
+        assertThat(third.hasNext()).isFalse();
+    }
+
+    @Test
+    void 채팅_페이지네이션_중간데이터삽입돼도_다음_불러오기에_영향_없어야함() throws JsonProcessingException {
+        for (int i = 0; i < 55; i++) {
+            Chat testChat = Chat.builder().roomId("TEST").memberId("%d".formatted(i)).content("테스트메시지%d".formatted(i)).build();
+            cachedChatRepository.save(testChat);
+        }
+
+        Cursor<Chat> first = cachedChatRepository.findByRoom("TEST", null);
+        Cursor<Chat> second = cachedChatRepository.findByRoom("TEST", first.getNextCursor());
+        Chat testChat1 = Chat.builder().roomId("TEST").content("새로운채팅1").build();
+        cachedChatRepository.save(testChat1);
+        Chat testChat2 = Chat.builder().roomId("TEST").content("새로운채팅2").build();
+        cachedChatRepository.save(testChat2);
+        Cursor<Chat> third = cachedChatRepository.findByRoom("TEST", second.getNextCursor());
+
+        assertThat(first).hasSize(20);
+        assertThat(first.hasNext()).isTrue();
+        assertThat(second).hasSize(20);
+        assertThat(second.hasNext()).isTrue();
+        assertThat(third).hasSize(15);
+        assertThat(third.hasNext()).isFalse();
+
+        assertThat(first.getContent().get(0).getCreateDate()).isAfter(third.getContent().get(0).getCreateDate());
+    }
+}

--- a/src/test/java/com/ll/MOIZA/boundedContext/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/com/ll/MOIZA/boundedContext/chat/repository/ChatRepositoryTest.java
@@ -62,6 +62,6 @@ class ChatRepositoryTest {
         chatRepository.saveAll(List.of(chat1, chat2, chat3, chat4));
         List<Chat> chatOfRoom1 = chatRepository.findByRoomId("1");
 
-        assertThat(chatOfRoom1.stream().map(Chat::getWriter)).containsExactlyInAnyOrder("글쓴이", "글쓴이2");
+        assertThat(chatOfRoom1.stream().map(Chat::getWriter)).contains("글쓴이", "글쓴이2");
     }
 }

--- a/src/test/java/com/ll/MOIZA/boundedContext/room/controller/MockedRoomControllerTest.java
+++ b/src/test/java/com/ll/MOIZA/boundedContext/room/controller/MockedRoomControllerTest.java
@@ -5,6 +5,7 @@ import com.ll.MOIZA.base.mail.MailService;
 import com.ll.MOIZA.boundedContext.chat.repository.ChatRepository;
 import com.ll.MOIZA.boundedContext.member.entity.Member;
 import com.ll.MOIZA.boundedContext.member.service.MemberService;
+import com.ll.MOIZA.boundedContext.result.service.ResultService;
 import com.ll.MOIZA.boundedContext.room.entity.Room;
 import com.ll.MOIZA.boundedContext.room.service.EnterRoomService;
 import com.ll.MOIZA.boundedContext.room.service.RoomService;
@@ -51,7 +52,7 @@ public class MockedRoomControllerTest {
     MailService mailService;
 
     @MockBean
-    EnterRoomService enterRoomService;
+    ResultService resultService;
 
     /*
     실제 메일 날라옴

--- a/src/test/java/com/ll/MOIZA/boundedContext/room/repository/RoomRepositoryTest.java
+++ b/src/test/java/com/ll/MOIZA/boundedContext/room/repository/RoomRepositoryTest.java
@@ -22,6 +22,8 @@ class RoomRepositoryTest {
 
     @BeforeEach
     void 데이터셋_준비() {
+        roomRepository.deleteAll();
+
         Room room1 = Room.builder()
                 .name("needToSendMail1")
                 .deadLine(LocalDateTime.now().minus(1, ChronoUnit.MINUTES))


### PR DESCRIPTION
- 방마다 최대 500개의 메시지를 redis에 캐싱
- 500개가 넘어가면 250개를 db로 벌크삽입

- 페이지네이션으로 데이터를 읽을때도 캐시에서 읽도록 수정

단 벌크삽입 후, 다른 사용자가 redis의 데이터를 다 읽은 상태에서 페이지네이션을 하면 이미 읽었던 채팅이 또 불러와질 수 있음
(어차피 메시지 500개를 더 불러오는 경우는 적을 것 같아서 일단 패스)

_**로컬에 Redis 설치해야 돌아갑니다.**_